### PR TITLE
Fixed AdaBoost ensemble size

### DIFF
--- a/src/GClasses/GEnsemble.cpp
+++ b/src/GClasses/GEnsemble.cpp
@@ -740,7 +740,7 @@ void GResamplingAdaBoost::trainInnerInner(const GMatrix& features, const GMatrix
 		if(err >= 0.5)
 		{
 			delete(pClone);
-			break;
+			continue;
 		}
 		double weight = 0.5 * log((1.0 - err) / err);
 		m_models.push_back(new GWeightedModel(weight, pClone));
@@ -760,6 +760,10 @@ void GResamplingAdaBoost::trainInnerInner(const GMatrix& features, const GMatrix
 			pDistribution[i] *= exp(weight * (err * 2.0 - 1.0));
 		}
 		pDistribution.sumToOne();
+	}
+	if (m_models.empty()) 
+	{
+		throw Ex("No valid models found for AdaBoost");
 	}
 	normalizeWeights();
 }

--- a/src/GClasses/GEnsemble.h
+++ b/src/GClasses/GEnsemble.h
@@ -350,7 +350,7 @@ public:
 	/// set). The default is 1.0.
 	void setTrainSize(double d) { m_trainSize = d; }
 
-	/// Specify the size of the ensemble. The default is 30.
+	/// Specify the maximum number of learners to ensemble. The default is 30.
 	void setSize(size_t n) { m_ensembleSize = n; }
 
 protected:


### PR DESCRIPTION
It shouldn't stop after finding the first "bad" learner.
Throwing an exception in case we didn't find any valid model.