### PR TITLE
Add option to compile a shared library.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
+option(BUILD_SHARED "Build shared libraries" OFF)
+
 add_subdirectory (GClasses)
 add_subdirectory (audio)
 add_subdirectory (cluster)

--- a/src/GClasses/CMakeLists.txt
+++ b/src/GClasses/CMakeLists.txt
@@ -35,17 +35,21 @@ INCLUDE_DIRECTORIES(.)
 #And build a static library
 SET (LIBRARY_OUTPUT_PATH ../../lib/ CACHE PATH "Output directory libraries.")
 SET (EXECUTABLE_OUTPUT_PATH ../../bin/ CACHE PATH "Output directory for executables.")
-ADD_LIBRARY(GClasses STATIC ${WAFFLES_SRCS} ${WAFFLES_HDRS})
+
+IF(BUILD_SHARED)
+	SET(LIB_TYPE "SHARED")
+ELSE()
+	SET(LIB_TYPE "STATIC")
+ENDIF()
+ADD_LIBRARY(GClasses ${LIB_TYPE} ${WAFFLES_SRCS} ${WAFFLES_HDRS})
 #SET_TARGET_PROPERTIES( GClasses PROPERTIES COMPILE_FLAGS "-DWAFFLES_EXPORTS") 
 
 #-------------------------------------------------------------------------------
 INSTALL(
-  TARGETS
-    GClasses
-  ARCHIVE DESTINATION 
-    lib
-  RUNTIME DESTINATION
-    bin
+  TARGETS GClasses
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 


### PR DESCRIPTION
It's not always possible to link a project to a statically compiled GClasses library. In such cases it is helpful to provide an option to compile shared library.

Usage: `cmake -DBUILD_SHARED=[ON|OFF] ..`

By default, compiles a static library.